### PR TITLE
Make relative import correct

### DIFF
--- a/marve/Measurements.py
+++ b/marve/Measurements.py
@@ -28,7 +28,7 @@ import json
 from collections import OrderedDict
 import logging
 # custom
-from classes import Stats, Annotations
+from .classes import Stats, Annotations
 from grobid_quantities.quantities import QuantitiesClient
 
 


### PR DESCRIPTION
The relative import from `classes.py` needs to be preceded by a period, otherwise this doesn't work and throws an error